### PR TITLE
Remove css rule transforming text to lower case.

### DIFF
--- a/components/ngc-float-item-button.component.ts
+++ b/components/ngc-float-item-button.component.ts
@@ -42,7 +42,6 @@ import {
     margin-right: 50px;
     line-height: 25px;
     color: white;
-    text-transform: lowercase;
     padding: 2px 7px;
     border-radius: 3px;
     display: none;


### PR DESCRIPTION
As demonstrated in images on material.io/design, lowercase text is not required and limits flexibility for users.
Fixes: https://github.com/GustavoCostaW/ngc-float-button/issues/20